### PR TITLE
Styles documents lists and other associated ui elements

### DIFF
--- a/packages/models/documents.coffee
+++ b/packages/models/documents.coffee
@@ -7,3 +7,12 @@ Document = Astro.Class
     title: 'string'
     body: 'string'
     groupId: 'string'
+
+  methods:
+    truncatedBody: ->
+      splitText = @body?.split(' ')
+      wordCount = 25
+      if splitText?.length > wordCount
+        splitText.slice(0,wordCount).join(' ')+'...'
+      else
+        @body

--- a/packages/models/tests/server/documents_test.coffee
+++ b/packages/models/tests/server/documents_test.coffee
@@ -14,6 +14,11 @@ describe 'Document', ->
     document.save
     expect(document.body).to.eq('Body text here')
 
+  it 'truncates body', ->
+    document.set('body', """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse leo risus, blandit non sem in, tempus tempor ex. Curabitur a mauris at orci sagittis scelerisque. Morbi ligula sapien, viverra ac condimentum vitae, maximus in massa. Aenean convallis est non odio feugiat condimentum. Morbi sollicitudin sit amet quam ac venenatis. Aenean id facilisis nisl. Interdum et malesuada fames ac ante ipsum primis in faucibus. Cras eu sem condimentum, congue turpis viverra, dictum elit. Nullam ornare nisi leo, ac aliquet ante pretium et. Proin volutpat tortor eu est blandit, sit amet ultricies nisl vulputate. Nullam malesuada aliquet orci, id vehicula quam dictum a. Nulla quis mollis leo. Donec dapibus justo nec enim ultricies auctor. Duis fringilla velit ut ex tempus, nec lobortis tellus pretium. Sed sit amet ligula ac odio efficitur convallis sed at massa.""")
+    truncatedBody = document.truncatedBody()
+    expect(truncatedBody.split(' ')).length('25')
+
   it 'includes groupId', ->
     document.set('groupId', 'fakeid')
     document.save

--- a/packages/styles/globals.import.styl
+++ b/packages/styles/globals.import.styl
@@ -27,7 +27,7 @@ h5
   color $d-gray
 
 .view-header
-  margin-bottom 15px
+  margin-bottom 25px
   +below(1)
     margin-bottom 25px
   h1
@@ -123,6 +123,17 @@ a
 .inline
   display inline-block
   vertical-align middle
+
+.full-width-table
+  border-top 1px solid $l-gray
+  .table-content-wrap
+    border-bottom 1px solid $l-gray
+    .container
+        padding 15px 0
+  td.title
+    font-size 120%
+    font-weight bold
+
 
 for $num in 1 2 3 4 5 6
   .space-btm-{$num}

--- a/packages/styles/groups.import.styl
+++ b/packages/styles/groups.import.styl
@@ -1,13 +1,5 @@
-.groups-table
-  border-top 1px solid $l-gray
-  .group-wrap
-    border-bottom 1px solid $l-gray
-    .container
-        padding 20px 0
-
 .group-name
   font-size 1.4em
   font-weight 600
   +below(1)
     font-size 1.25em
-

--- a/packages/styles/header.import.styl
+++ b/packages/styles/header.import.styl
@@ -29,6 +29,17 @@ header
       background white
       outline $primary
       transition()
+    &.new-document
+      float left
+      margin-left 20px
+      margin-top 11px
+      &:hover
+      &:focus
+        color white
+      +below(2)
+        float none
+        width 60%
+        margin 10px auto
 
 .nav
   float right
@@ -94,7 +105,7 @@ header
           transition(background-color)
           background $primary
           @extend .dark-shadow
-          color white
+          color $body-text
         +below(1)
           float none
           width 50%

--- a/packages/views/document_form.jade
+++ b/packages/views/document_form.jade
@@ -1,13 +1,15 @@
 template(name="documentForm")
   .container
+    h1 New Document
     .row
-      .col-sm-12
-        h1 New Document
-    .row
-      .col-sm-12
+      .col-sm-10
         form#new-document-form
-          label Title
-            input#document-title.form-control(type='string' name='title')
-          label Body
-            textarea#document-body.form-control(name='body')
+          .row
+            .col-sm-6
+              label Title
+                input#document-title.form-control(type='string' name='title')
+          .row
+            .col-sm-10
+              label Body
+              textarea#document-body.form-control(name='body')
           input.btn.btn-primary(type="submit" value="Save")

--- a/packages/views/documents.jade
+++ b/packages/views/documents.jade
@@ -1,10 +1,16 @@
 template(name="documents")
   .documents
-    .container
-      .row
-        .col-sm-12
-          h1 All Documents
-      .row
-        .col-sm-12
-          each documents
-            p= title
+    .view-header
+      .container
+        h1 All Documents
+    table.table.table-striped.full-width-table
+      tbody
+        each documents
+          tr.table-content-wrap
+            .container
+              .row
+                .col-sm-3
+                  td.title= title
+                .col-sm-9
+                  td.document-description {{truncatedBody}}
+

--- a/packages/views/group_detail.jade
+++ b/packages/views/group_detail.jade
@@ -1,11 +1,13 @@
 template(name="groupDetail")
-  .group-detail
+  .group-detail.space-btm-3
+    .view-header
+      .container
+        h1.inline #{group.name}
+        a.group-documents-link.btn.header-btn.btn-default(href="{{path route='groupDocuments' params=groupDocumentsParams}}")
+          span Documents
+          i.fa.fa-files-o
     .container
-      h1 Group: #{group.name}
       .row
         .col-sm-10
           +paragraphText text=group.description
-      .row
-        .col-sm-10
-          a.group-documents-link.btn.btn-default(href="{{path route='groupDocuments' params=groupDocumentsParams}}") Documents
   +userForm groupId=group._id

--- a/packages/views/group_documents.jade
+++ b/packages/views/group_documents.jade
@@ -1,13 +1,20 @@
 template(name="groupDocuments")
   .group-documents.documents
-    .container
-      h1= group.name
-      if showNewDocumentLink
-        .row
-          .col-sm-10
-            a.new-document-link.btn.btn-default(href="{{path route='newDocument' params=newDocumentParams}}") New Document
-
-      .row
-        .col-sm-10
-          each documents
-            p= title
+    .view-header
+      .container
+        h1.inline= group.name
+        if isAdmin
+          if showNewDocumentLink
+            a.new-document-link.btn.header-btn.btn-default(href="{{path route='newDocument' params=newDocumentParams}}")
+              span New Document
+              i.fa.fa-file-text-o
+    table.table.table-striped.full-width-table
+      tbody
+        each documents
+          tr.table-content-wrap
+            .container
+              .row
+                .col-sm-3
+                  td.title= title
+                .col-sm-9
+                  td.document-description {{truncatedBody}}

--- a/packages/views/groups.jade
+++ b/packages/views/groups.jade
@@ -1,18 +1,19 @@
 template(name="groups")
   if currentUser
-    .container.view-header
-      h1.inline Groups
-      a.btn.btn-default.new-group-link.header-btn(href="{{path route='newGroup'}}")
-        span Create
-        i.fa.fa-plus
-    table.table.table-striped.groups-table
+    .view-header
+      .container
+        h1.inline Groups
+        a.btn.btn-default.new-group-link.header-btn(href="{{path route='newGroup'}}")
+          span Create
+          i.fa.fa-plus
+    table.table.table-striped.full-width-table
       tbody
         each groups
-          tr.group-wrap
+          tr.table-content-wrap
             .container
               .row
                 .col-sm-3
-                  td
+                  td.title
                     a.group-name(href="{{path route='groupDetail' params=this}}")= name
                 .col-sm-9
                   td.group-description {{truncateDescription}}

--- a/packages/views/header.jade
+++ b/packages/views/header.jade
@@ -7,18 +7,24 @@ template(name="header")
           a.navbar-brand(href="/")
             h1 Tater
         .navbar-collapse.collapse
+          if currentUser
+            unless isAdmin
+              ul.nav.navbar-nav.navbar-left
+                li
+                  a.btn.navbar-btn.new-document(href="{{path route='newDocument' params=documentsLinkParams}}")
+                    span New Document
+                    i.fa.fa-file-text-o
           ul.nav.navbar-nav.navbar-right
-            if currentUser
-              if isAdmin
-                li
-                  a.header-documents-link(href="{{path route='documents'}}")
-                    span Documents
-                li
-                  a(href="{{path route='groups'}}")
-                    span Groups
-              else
-                li
-                  a.header-documents-link(href="{{path route='groupDocuments' params=documentsLinkParams}}")
-                    span Documents
+            if isAdmin
+              li
+                a.header-documents-link(href="{{path route='documents'}}")
+                  span Documents
+              li
+                a(href="{{path route='groups'}}")
+                  span Groups
+            else
+              li
+                a.header-documents-link(href="{{path route='groupDocuments' params=documentsLinkParams}}")
+                  span Documents
             +accountsHeaderButtons state=accountsState
   +accountsModal state=accountsState

--- a/packages/views/user_form.jade
+++ b/packages/views/user_form.jade
@@ -1,6 +1,6 @@
 template(name="userForm")
   .container
-    h1 Add a user
+    h3 Add a user
     .row
       .col-sm-8
         form#new-user-form


### PR DESCRIPTION
The lists are pretty simple at this point so I made them consistent with the styling of group lists.
I also added a new document button to the header which shows only for non-admin since their documents are associated with one group and should have immediate access to this action. I decided to hide it on the documents page of a group for non-admin because I thought it was redundant.
