### PR TITLE
Give group name more space before truncating on documents page

### DIFF
--- a/packages/styles/documents.import.styl
+++ b/packages/styles/documents.import.styl
@@ -34,16 +34,20 @@
       text-decoration none
 
   .document-title
-    padding-right 22%
+  .document-group
+    truncateString()
+
+  .document-title
+    width 55%
     font-size 1.1em
+    float left
 
   .document-group
-    centerVertically()
-    right 15px
     width 40%
-    truncateString()
+    float right
     text-align right
     color darken($m-gray, 10%)
+    font-size 95%
     font-style italic
 
 .delete-document-button

--- a/packages/views/documents.jade
+++ b/packages/views/documents.jade
@@ -8,7 +8,7 @@ template(name="documents")
         ul.list.document-list.list-unstyled
           each documents
             li.document
-                a.list-link(href="{{path route='documentDetail' params=this}}")
+                a.list-link.clearfix(href="{{path route='documentDetail' params=this}}")
                   span.document-title= title
                   span.document-group= groupName
       else

--- a/packages/views/group_documents.jade
+++ b/packages/views/group_documents.jade
@@ -17,7 +17,7 @@ template(name="groupDocuments")
         ul.document-list.list.list-unstyled
           each documents
             li.document
-                a.list-link(href="{{path route='documentDetail' params=this}}")
+                a.list-link.clearfix(href="{{path route='documentDetail' params=this}}")
                   span.document-title= title
                 button.btn-plain.delete-document-button(data-toggle="modal" data-document-id=_id data-target="#confirm-delete-document-modal" )
                   i.fa.fa-trash-o


### PR DESCRIPTION
@jgoley this is a super quick fix that introduces a new issue - it's now possible for document names and group names to overlap at small screen sizes.  Do you think that's an issue?  Is there an easy way to also truncate the document name? I tried copying "truncateString()" onto the document title but it didn't seem to do anything.
