### PR TITLE
Temporarily hide Edit Coding Keyword interface from users

### DIFF
--- a/packages/views/admin.jade
+++ b/packages/views/admin.jade
@@ -22,8 +22,6 @@ template(name="admin")
                   i.fa.fa-user-plus
             .users-container
               +users
-      .container
-        +editCodingKeywords
   else
     .container
       .row


### PR DESCRIPTION
We're going to rework this interface a little bit.  Hiding this part of the interface will prevent users from getting confused.  We still have the interface at /editCodingKeywords, so our end-to-end tests still work, but there are no links to that URL in the interface.
