### PR TITLE
Write Meteor method for creating default admin users

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,5 +1,7 @@
 accounts-base@1.2.0
 accounts-password@1.1.1
+accounts-ui@1.1.5
+accounts-ui-unstyled@1.1.7
 amplify@1.0.0
 anti:i18n@0.4.3
 aslagle:reactive-table@0.8.11

--- a/packages/accounts/default_user.coffee
+++ b/packages/accounts/default_user.coffee
@@ -1,0 +1,4 @@
+Meteor.methods
+  createDefaultUser: (email, password) ->
+    if (!Meteor.users.find().count())
+      Accounts.createUser(email: email, password: password, admin: true)

--- a/packages/accounts/package.js
+++ b/packages/accounts/package.js
@@ -8,7 +8,9 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom('1.1.0.2');
   api.use(['coffeescript', 'ui']);
+  api.use('accounts-ui');
   api.use('aslagle:reactive-table');
   api.addFiles('user_publications.coffee', ['server', 'client']);
   api.addFiles('admin_helper.coffee', ['client']);
+  api.addFiles('default_user.coffee', ['server']);
 });


### PR DESCRIPTION
There doesn't seem to be a good way to create Meteor user records outside of the context of the app.  This approach is an improvement over my previous PR because the previous one tried to create an admin user on startup, whereas this method needs to be manually invoked.  We may still need to figure out a way to call this method automatically when a new Tater instance is set up.

To add a user, go into the browser's console and type
`Meteor.call('createDefaultUser', YOUR_USERNAME, YOUR_PASSWORD)`
