### PR TITLE
Fix search coding keywords bug

### DIFF
--- a/packages/controllers/coding_keywords.coffee
+++ b/packages/controllers/coding_keywords.coffee
@@ -19,7 +19,7 @@ if Meteor.isClient
         text = RegExp(text, 'i')
         query.push $or: [{'header': text}, {'subHeader': text}, {'keyword': text}]
 
-      if instance.selectableCodes.get()
+      if instance.selectableCodes?.get()
         codeIds = _.pluck instance.selectableCodes.get(), '_id'
         query.push {_id: {$in: codeIds}}
 
@@ -104,7 +104,7 @@ if Meteor.isClient
       Template.instance().data.action is 'coding'
 
     selected: (codeId) ->
-      if Template.instance().data.selectedCodes.findOne(@_id)
+      if Template.instance().data.selectedCodes?.findOne(@_id)
         'selected'
 
     selectedCodes: ->


### PR DESCRIPTION
We currently use this codingKeyword template in very different ways on the Document Detail page and the Search Annotations page - I'm going to refactor this and split them into separate templates to prevent issues like this in the future.
