### PR TITLE
Adding BOM to indicate CSV encoding to Excel

### DIFF
--- a/packages/controllers/annotations.coffee
+++ b/packages/controllers/annotations.coffee
@@ -357,7 +357,11 @@ if Meteor.isServer
           text: (annotation)-> annotation.text().string
           flagged: (annotation)-> Boolean(annotation.flagged)
           createdAt: (annotation)-> annotation.createdAt
-        Baby.unparse
+        # This BOM is needed to make modern versions of Excel open the CSV
+        # using the correct encoding.
+        # See: http://stackoverflow.com/questions/155097/microsoft-excel-mangles-diacritics-in-csv-files
+        excelBOM = '\uFEFF'
+        excelBOM + Baby.unparse
           fields: _.keys(headerGetters)
           data: Annotations.find(query).map((annotation)->
             _.map(headerGetters, (getValue, header)->

--- a/tests/cucumber/features/step_definitions/search_annotations_steps.coffee
+++ b/tests/cucumber/features/step_definitions/search_annotations_steps.coffee
@@ -54,7 +54,7 @@ do ->
         .click('.download-csv')
 
     @Then /^I should see a link that downloads the generated CSV with header "([^"]*)" and key "([^"]*)"$/, (header, keyword) ->
-      csvData = """documentId,userEmail,header,subHeader,keyword,text,flagged,createdAt\r
+      csvData = """\uFEFFdocumentId,userEmail,header,subHeader,keyword,text,flagged,createdAt\r
       fakedocumentid,,"""+header+""",,"""+keyword+""",T,false,"""
       @browser
         .waitForExist '#download-csv-modal .btn-primary'


### PR DESCRIPTION
This adds a byte order marker to hopefully make versions of Excel after 2007 open exported CSVs using a UTF8 encoding. See the discussion here for further details: https://www.pivotaltracker.com/story/show/106052786
