### PR TITLE
Use document interface to ensure documents are created in correct order

### DIFF
--- a/packages/fixtures/fixtures.coffee
+++ b/packages/fixtures/fixtures.coffee
@@ -36,6 +36,7 @@ do ->
     'createTestDocument': (attributes) ->
       attributes['body'] ?= 'Test Body'
       attributes['groupId'] ?= 'fakegroupid'
+      attributes['createdAt'] ?= new Date()
       Documents.insert(attributes)
 
     'createTestAnnotation': (attributes) ->


### PR DESCRIPTION
This test was failing intermittently.  I decided to ensure the documents are created in the proper order by creating one in the background for the test and creating the other one via the user interface.  I'm open to the idea of creating both documents via the interface if it seems weird to create them in two different ways.
