### PR TITLE
Adding revision.txt server route

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -5,6 +5,7 @@
 # but you can also edit it by hand.
 
 tater:router
+tater:server-router
 xolvio:cucumber
 tater:models
 tater:fixtures

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -57,6 +57,7 @@ meteor-base@1.0.1
 meteor-platform@1.2.3
 meteorhacks:flow-layout@1.3.0
 meteorhacks:flow-router@1.9.0
+meteorhacks:picker@1.0.3
 minifiers@1.1.7
 minimongo@1.0.10
 mobile-experience@1.0.1
@@ -100,6 +101,7 @@ tater:models@0.0.1
 tater:query-helpers@0.0.1
 tater:route-helpers@0.0.1
 tater:router@0.0.1
+tater:server-router@0.0.1
 tater:styles@0.0.1
 tater:views@0.0.1
 templating@1.1.5

--- a/packages/server-router/package.js
+++ b/packages/server-router/package.js
@@ -1,0 +1,13 @@
+Package.describe({
+  name: 'tater:server-router',
+  version: '0.0.1',
+  summary: 'Server-side routing for tater',
+  git: ''
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom('1.1.0.2');
+  api.use('coffeescript');
+  api.use('meteorhacks:picker');
+  api.addFiles('router.coffee', ['client', 'server']);
+});

--- a/packages/server-router/router.coffee
+++ b/packages/server-router/router.coffee
@@ -1,0 +1,10 @@
+fs = Npm.require('fs')
+path = Npm.require('path')
+Picker.route '/revision.txt', (params, req, res, next) ->
+  appDirectory = path.join(process.cwd().split('tater')[0], 'tater')
+  fs.readFile path.join(appDirectory, 'revision.txt'), 'utf8', (err, data)->
+    if err
+      console.log(err)
+      res.end("Error getting revision. Check the server log for details.")
+    else
+      res.end(data)


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/107416186

This adds a server side route at "/revision.txt" that displays the content of the "revision.txt" file in the app directory.

We will need to add a command like this to our ansible playbook for this to work.
`git log -1 --format="%H : %ai" > revision.txt`
