### PR TITLE
Use astronomy models for all fixtures except coding keywords

### DIFF
--- a/packages/fixtures/fixtures.coffee
+++ b/packages/fixtures/fixtures.coffee
@@ -20,30 +20,38 @@ do ->
       Meteor.users.update({_id: account}, {$set: {admin: true}})
 
     'createTestGroup': (codeAccessible) ->
-      Groups.insert
+      group = new Group()
+      group.set
         name: "Test Group"
         description: "Test Description"
         createdById: Meteor.users.findOne()._id
         _id: "fakegroupid"
         codeAccessible: codeAccessible
+      group.save()
 
     'createProfile': (field, value, id) ->
+      userProfile = new UserProfile()
       attributes = {}
       attributes[field] = value
       attributes['_id'] = id
-      UserProfiles.insert attributes
+      userProfile.set(attributes)
+      userProfile.save()
 
     'createTestDocument': (attributes) ->
+      document = new Document()
       attributes['body'] ?= 'Test Body'
       attributes['groupId'] ?= 'fakegroupid'
-      Documents.insert(attributes)
+      document.set(attributes)
+      document.save()
 
     'createTestAnnotation': (attributes) ->
+      annotation = new Annotation()
       attributes['documentId'] ?= 'fakedocumentid'
       attributes['userId'] ?= 'fakeuserid'
       attributes['startOffset'] ?= 0
       attributes['endOffset'] ?= 1
-      Annotations.insert(attributes)
+      annotation.set(attributes)
+      annotation.save()
 
     'createCodingKeyword': (attributes) ->
       CodingKeywords.insert(attributes)

--- a/packages/fixtures/package.js
+++ b/packages/fixtures/package.js
@@ -11,5 +11,6 @@ Package.onUse(function(api) {
   api.versionsFrom('1.1.0.2');
   api.use('accounts-base');
   api.use('coffeescript');
+  api.use('tater:models');
   api.addFiles('fixtures.coffee');
 });


### PR DESCRIPTION
For some reason, using the coding keywords model broke some tests - I'll look into that more, but I think we should merge this asap so that our fixtures more accurately reflect our app.
