### PR TITLE
Don't include server-side router code on client

### DIFF
--- a/packages/server-router/package.js
+++ b/packages/server-router/package.js
@@ -9,5 +9,5 @@ Package.onUse(function(api) {
   api.versionsFrom('1.1.0.2');
   api.use('coffeescript');
   api.use('meteorhacks:picker');
-  api.addFiles('router.coffee', ['client', 'server']);
+  api.addFiles('router.coffee', ['server']);
 });


### PR DESCRIPTION
This removes an error that we're currently seeing in the console.
