### PR TITLE
the document list is sorted by date

### DIFF
--- a/packages/controllers/document_list.coffee
+++ b/packages/controllers/document_list.coffee
@@ -2,6 +2,8 @@ DocumentListPages = new Meteor.Pagination Documents,
   perPage: 10,
   templateName: 'documentList'
   itemTemplate: 'document'
+  sort:
+    createdAt: -1
   availableSettings:
     perPage: true
     filters: true
@@ -54,4 +56,3 @@ if Meteor.isClient
   Template.document.helpers
     groupName: ->
       Template.instance().document.groupName()
-


### PR DESCRIPTION
No indicator, but the documents are being sorted by date, DESC

As a suggestion, I think we should have a drop-down on the top, and an option to sort by the tstamp of upload and by the latest annotation tstamp.
