### PR TITLE
Stop trying to add code accessible keywords to the db on startup

### DIFF
--- a/packages/models/coding_keywords.coffee
+++ b/packages/models/coding_keywords.coffee
@@ -199,11 +199,6 @@ codes =
       'Feasts/holy days'
     ]
 
-caseCountCodes = [
-  'Case count'
-  'Death count'
-]
-
 CodingKeywords = new Mongo.Collection('keywords')
 CodingKeyword = Astro.Class
   name: 'CodingKeyword'
@@ -245,12 +240,3 @@ if Meteor.isServer
             CodingKeywords.insert
               'label': keyword
               'subHeaderId': subHeaderId
-
-    i = 0
-    for header in caseCountCodes
-      unless CodingKeywords.findOne({header: header})
-        i++
-        CodingKeywords.insert
-          'header': header
-          'color': i
-          'caseCount': true


### PR DESCRIPTION
This was causing warnings in the server log.
