### PR TITLE
Highlight click

### DIFF
--- a/.scripts/restore_database
+++ b/.scripts/restore_database
@@ -1,6 +1,6 @@
 #!/bin/bash
-ssh -i ~/.ssh/infrastructure.pem ubuntu@eha.tater.io mongodump
-scp -r -i ~/.ssh/infrastructure.pem ubuntu@eha.tater.io:dump/ dump/
-ssh -i ~/.ssh/infrastructure.pem ubuntu@eha.tater.io "rm -rf dump/"
+ssh -i ~/.ssh/infrastructure.pem ubuntu@tater.ecohealthalliance.org mongodump
+scp -r -i ~/.ssh/infrastructure.pem ubuntu@tater.ecohealthalliance.org:dump/ dump/
+ssh -i ~/.ssh/infrastructure.pem ubuntu@tater.ecohealthalliance.org "rm -rf dump/"
 mongorestore --drop --port 3001 -d meteor dump/tater
 rm -rf dump/

--- a/packages/controllers/document_detail.coffee
+++ b/packages/controllers/document_detail.coffee
@@ -63,18 +63,11 @@ if Meteor.isClient
             highlightText(id)
             scrollToAnnotation(id)
         else if selectedAnnotation.onLoad
-<<<<<<< HEAD
           if Annotations.findOne(id)
             setTimeout (->
                 scrollToAnnotation(id, true)
                 highlightText(id)
               ), 1000
-=======
-          setTimeout (->
-            scrollToTextAnnotation(id, true)
-            highlightText(id)
-            ), 400
->>>>>>> d70eda7... working version without generating 'click' triggers
         else
           highlightText(id)
           scrollToTextAnnotation(id, false)
@@ -163,10 +156,7 @@ if Meteor.isClient
       # hide the top most layer before we begin processing annotation layers
       $('.document-wrapper > .document-text').hide()
       $('.document-annotations').each () ->
-        # elementAtPoint = document.elementFromPoint(event.clientX, event.clientY)
         elementAtPoint = document.elementFromPoint(event.pageX, event.pageY)
-        console.log event.pageX, event.pageY
-        console.log elementAtPoint
         if $(elementAtPoint).hasClass('annotation-highlight')
           $(elementAtPoint).trigger("click")
         if $(elementAtPoint).hasClass('document-text')

--- a/tests/cucumber/features/annotation_interface.feature
+++ b/tests/cucumber/features/annotation_interface.feature
@@ -1,4 +1,3 @@
-@dev
 Feature: Annotation interface
   Background:
     Given there is a test user in the database
@@ -36,14 +35,3 @@ Feature: Annotation interface
 
     When I type "Test" in the coding keyword search
     Then I should see coding keyword search results
-
-  @annotations
-  Scenario: Clicking highlighted text should take you to the annotation
-    Given there is a test document in the database
-    And there is a coding keyword with header "Test" in the database
-    When I log in as the test user
-    And I navigate to the annotation interface for the test document
-    And I highlight some document text
-    And I click on a coding keyword
-    And I click on some highlighted text
-    Then the annotation should be selected

--- a/tests/cucumber/features/step_definitions/accounts_steps.coffee
+++ b/tests/cucumber/features/step_definitions/accounts_steps.coffee
@@ -159,14 +159,3 @@ do ->
         .setValue('#at-field-password', 'newPassword')
         .submitForm('#at-field-email')
         .waitForExist('.sign-out')
-
-    @When 'I click on some highlighted text', ->
-      @browser
-        .moveToObject('.document-wrapper',5,5)
-        .click('.document-wrapper')
-        # .waitForExist('.annotation-highlight')
-        # .click('.annotation-highlight')
-
-    @Then 'the annotation should be selected', ->
-      @browser
-        .waitForExist('.annotations li.selected')


### PR DESCRIPTION
Not sure that we can create a test for this due to the way that we have document highlighting set up.  Currently we create a layer that sits on top of the document text for each highlight.  The added functionality takes the click event and applied it to each layer, and if text is highlighted beneath the click event on one of those layers it takes you to the annotation.  

The problem that is occurring with the tests is that when you attempt to click on the highlighted text an error is thrown stating that the target element it is not actually clickable (since it is beneath another element).
