### PR TITLE
hiding the 'Search Code Keywords' input if the keyword list is empty

### DIFF
--- a/packages/controllers/annotations_coding_keywords.coffee
+++ b/packages/controllers/annotations_coding_keywords.coffee
@@ -57,16 +57,19 @@ if Meteor.isClient
         instance.filteredCodes.set null
 
   Template.annotationsCodingKeywords.helpers
-    searching: () ->
+    searching: ->
       Template.instance().searching.get()
 
-    filteredCodes: () ->
+    hasCodes: ->
+      CodingKeywords.find().count() > 0
+
+    filteredCodes: ->
       Template.instance().filteredCodes.get()
 
-    code: () ->
+    code: ->
       Spacebars.SafeString("<span class='header'>#{@headerLabel()}</span> : <span class='sub-header'>#{@subHeaderLabel()}</span> : <span class='keyword'>#{@label}</span>")
 
-    selectableHeaders: () ->
+    selectableHeaders: ->
       if Template.instance().filteredHeaders.get()
         Template.instance().filteredHeaders.get()
       else

--- a/packages/views/annotations_coding_keywords.jade
+++ b/packages/views/annotations_coding_keywords.jade
@@ -1,9 +1,10 @@
 template(name="annotationsCodingKeywords")
   .code-search-container.pane-head.pane-head-r
     if Template.subscriptionsReady
-      input.code-search.form-control(type="text" placeholder="Search Code Keywords")
-      if searching
-        i.fa.fa-times-circle.clear-search
+      if hasCodes
+        input.code-search.form-control(type="text" placeholder="Search Code Keywords")
+        if searching
+          i.fa.fa-times-circle.clear-search
   .coding-container.pane.pane-r
     ul.list-unstyled.code-list.listing
       if selectedCodes


### PR DESCRIPTION
The list on the right on the /annotations page still blinks when we select/unselect document(s) on the right, but it's a separate issue. This is just a small fix to make the input field disappear when the list is empty.
