### PR TITLE
Velocity fixes for the "X" button and the logo in the side pane

### DIFF
--- a/packages/styles/main.styl
+++ b/packages/styles/main.styl
@@ -27,3 +27,5 @@
 @import 'document_detail.import'
 @import 'coding_keywords.import'
 @import 'annotations.import'
+
+@import 'velocity.import'

--- a/packages/styles/package.js
+++ b/packages/styles/package.js
@@ -38,5 +38,7 @@ Package.onUse(function(api) {
   api.addFiles('coding_keywords.import.styl');
   api.addFiles('annotations.import.styl');
 
+  api.addFiles('velocity.import.styl');
+
   api.addFiles('main.styl');
 });

--- a/packages/styles/velocity.import.styl
+++ b/packages/styles/velocity.import.styl
@@ -1,0 +1,5 @@
+#velocityOverlay
+  text-shadow none
+  .velocity-btn-close
+    z-index 1
+    outline none


### PR DESCRIPTION
Fixes the issue with the velocity button being not clickable in the sidebar.
Includes a few minor CSS fixes for the velocity side pane.
Mostly to make it easier to close the panel in cases when it just pops up in front of you in the dev. mode.
