### PR TITLE
Change name of Code Management interface and associated files/code

### DIFF
--- a/packages/views/coding_keywords.jade
+++ b/packages/views/coding_keywords.jade
@@ -1,7 +1,7 @@
 template(name="codingKeywords")
   .view-header.primary-bg
     .container
-      h1 Code Management
+      h1 Coding Keywords
 
   .container.code-management-container
     if Template.subscriptionsReady


### PR DESCRIPTION
Fixes a conflict in the name of the Code Management page and renames the files, template names, and tests. (Formerly "Coding Keywords" now "Code Management")
