### PR TITLE
Add space below header

### DIFF
--- a/packages/views/document_new.jade
+++ b/packages/views/document_new.jade
@@ -1,5 +1,5 @@
 template(name="documentNew")
-  .view-header.secondary-bg
+  .view-header.secondary-bg.space-btm-2
     .container
       h1 New Document
   .container

--- a/packages/views/group_form.jade
+++ b/packages/views/group_form.jade
@@ -1,6 +1,6 @@
 template(name="groupForm")
   if isAdmin
-    .view-header.secondary-bg
+    .view-header.secondary-bg.space-btm-2
       .container
         h1 Add a Group
     .container


### PR DESCRIPTION
Fixes a small visual bug where there was insufficient margin above the page content on /documents/new and /groups/new.
