### PR TITLE
2px top/bottom border added to all annotation highlights

### DIFF
--- a/packages/styles/document_detail.import.styl
+++ b/packages/styles/document_detail.import.styl
@@ -191,6 +191,10 @@
           &:hover
             color darken($color, 80%)
 
+.annotation-highlight
+  border-top 2px #FFF solid
+  border-bottom 2px #FFF solid
+
 for $color, $index in $annotation-colors
   .annotation-highlight-{$index+1}
     background-color alpha($color, 60%)


### PR DESCRIPTION
Prevents clicks from "falling through" annotation text highlights
