### PR TITLE
Truncate long coding keywords with ellipses

### DIFF
--- a/packages/styles/annotations.import.styl
+++ b/packages/styles/annotations.import.styl
@@ -12,8 +12,10 @@
   h3
     body-font()
     padding-left 15px
+    padding-right 20px
     font-size 1.5em
     font-weight 600
+    truncateString(false)
   for $color, $index in $annotation-colors
     &.color-{$index+1}
       h3

--- a/packages/styles/coding_keywords.import.styl
+++ b/packages/styles/coding_keywords.import.styl
@@ -194,10 +194,8 @@ checkMark(center=false)
 .code-keyword
   font-size 13px
   font-weight 400
-  overflow hidden
-  text-overflow ellipsis
   span
-    padding 0
+    truncateString(false)
     padding 5px 15px 5px 5px
 
 .filteredCodes
@@ -354,7 +352,7 @@ checkMark(center=false)
 
 .disabled
   color lighten($primary-light, 70%) !important
-  
+
 .disabled span::after
   content ' (archived)'
 

--- a/packages/styles/document_detail.import.styl
+++ b/packages/styles/document_detail.import.styl
@@ -148,12 +148,14 @@
     .code
       display block
       padding 25px 35px 25px 15px
+      truncateString(false)
     .user
       position absolute
       bottom 5px
       right 5px
       font-size .8em
       color alpha($body-color, 90%)
+
     for $color, $index in $annotation-colors
       .annotation-color-{$index+1}
         background-color $color

--- a/packages/styles/mixins.import.styl
+++ b/packages/styles/mixins.import.styl
@@ -162,8 +162,9 @@ linkColor($color, $hover = darken($color, 35%))
   &:hover
     color $hover
 
-truncateString()
-  white-space nowrap
+truncateString($white-space=true)
+  if $white-space
+    white-space nowrap
   overflow hidden
   text-overflow ellipsis
 
@@ -175,3 +176,4 @@ borderRadius($tl,$tr,$br,$bl)
 
 selectedBG()
   background-color desaturate(lighten($primary-light, 90%), 70%)
+


### PR DESCRIPTION
Fixes a bug where a long coding keyword with no spaces was overflowing its container.
<img width="359" alt="screen shot 2015-12-22 at 12 40 40 pm" src="https://cloud.githubusercontent.com/assets/4105343/12151390/f28a2cac-b47c-11e5-8c69-7a1dbdc73a48.png">

Pivotal story: https://www.pivotaltracker.com/projects/1424346/stories/110579696
