### PR TITLE
Fix for header scrolling away on /annotations

### DIFF
--- a/packages/styles/globals.import.styl
+++ b/packages/styles/globals.import.styl
@@ -14,7 +14,6 @@ body
   min-height 100vh
 
 .content-wrap
-  margin-bottom 40px
   padding-bottom $footer-height-actual+10
 
 h2


### PR DESCRIPTION
The margin-bottom on the .content-wrap was causing the .page-wrap to exceed 100vh. If the margin is necessary, perhaps we could instead increase the padding to compensate. The padding on the .content-wrap does not seem to be necessary either, perhaps because the footer does not appear on most pages anymore. I think we should consider removing that as well.
