### PR TITLE
Fix spacing/position issues and remove group sorting for Regular users

### DIFF
--- a/packages/views/document_list.jade
+++ b/packages/views/document_list.jade
@@ -13,30 +13,31 @@ template(name="documentList")
           span.sr-only Toggle Dropdown
 
         ul.dropdown-menu.document-sorting-options
-          li.column(data-sort-by='lowerTitle' data-title='Title')
-            if sortBy 'lowerTitle' 1
-              i.fa.fa-caret-down
-            if sortBy 'lowerTitle' -1
-              i.fa.fa-caret-up
-            | Title
           li.column(data-sort-by='createdAt' data-title='Date Created')
             if sortBy 'createdAt' 1
               i.fa.fa-caret-down
             if sortBy 'createdAt' -1
               i.fa.fa-caret-up
             | Date Created
+          li.column(data-sort-by='lowerTitle' data-title='Title')
+            if sortBy 'lowerTitle' 1
+              i.fa.fa-caret-down
+            if sortBy 'lowerTitle' -1
+              i.fa.fa-caret-up
+            | Title
           li.column(data-sort-by='annotated' data-title='Number of Annotations')
             if sortBy 'annotated' 1
               i.fa.fa-caret-down
             if sortBy 'annotated' -1
               i.fa.fa-caret-up
             | Number of Annotations
-          li.column(data-sort-by='groupName' data-title='Document Group')
-            if sortBy 'groupName' 1
-              i.fa.fa-caret-down
-            if sortBy 'groupName' -1
-              i.fa.fa-caret-up
-            | Document Group
+          if isAdmin
+            li.column(data-sort-by='groupName' data-title='Document Group')
+              if sortBy 'groupName' 1
+                i.fa.fa-caret-down
+              if sortBy 'groupName' -1
+                i.fa.fa-caret-up
+              | Document Group
     .form-group.document-search-wrap
       i.fa.fa-search
       input.form-control.document-search(placeholder="Search Documents")

--- a/packages/views/group_documents.jade
+++ b/packages/views/group_documents.jade
@@ -3,6 +3,8 @@ template(name="groupDocuments")
     .view-header.primary-bg
       .container
         h1.inline Documents
+          a.help-link(href="../../help?topic=documents")
+            i.fa.fa-question-circle
         if showNewDocumentLink
           a.new-document-link.btn.header-btn.btn-primary(href="{{path route='newDocument' params=newDocumentParams}}")
             span Add Document
@@ -10,5 +12,5 @@ template(name="groupDocuments")
         p.group-name
           span Document Group:
           | #{group.name}
-    .container
+    .container.container-list
       +documentList group=group

--- a/packages/views/splash_page.jade
+++ b/packages/views/splash_page.jade
@@ -3,7 +3,7 @@ template(name="splashPage")
     if isAdmin
       .groups-users
         +admin
-    .container.spash-user-content
+    .container.spash-user-content.space-top-3
       .row
         .col-sm-8
           h4 Add a New Document


### PR DESCRIPTION
Fixes spacing on Regular user splash page and document list.
I also removed document sorting by group for regular users since the only see documents from their group.

PT Bug: https://www.pivotaltracker.com/story/show/111774726
