### PR TITLE
cancel() mechanism improved, jobs are being cancelled before the document is removed

### DIFF
--- a/packages/controllers/create_mturk_job_modal.coffee
+++ b/packages/controllers/create_mturk_job_modal.coffee
@@ -9,6 +9,8 @@ if Meteor.isClient
       Math.floor(MTurkJob.getFields().HITLifetimeInSeconds.default / 60)
 
   Template.createMTurkJobModal.events
+    'submit form': (event, instance) ->
+      event.preventDefault()
     'click .clear-title': (event, instance) ->
       console.log instance.$('*')
       instance.$('input[name=title]').val('')

--- a/packages/controllers/delete_document_modal.coffee
+++ b/packages/controllers/delete_document_modal.coffee
@@ -8,12 +8,12 @@ if Meteor.isClient
       unless $button.hasClass noClickClassName
         $button.addClass noClickClassName
         documentId = $button.attr('data-document-id')
-        Meteor.call 'deleteDocument', documentId, (error, isServer) ->
+        Meteor.call 'deleteDocument', documentId, (error, isClient) ->
           if error
             toastr.error('Server Error')
           else
             toastr.success('Success')
-          if isServer
+          if isClient
             $button.removeClass noClickClassName
 
 
@@ -26,7 +26,7 @@ Meteor.methods
     if not document then throw new Meteor.Error('Document does not exist.')
     group = Groups.findOne(document.groupId)
     if group?.viewableByUser(user)
-      Documents.remove(documentId)
+      document.remove()
       Annotations.remove(documentId: documentId)
     else
       throw new Meteor.Error('Document is not accessible.')

--- a/packages/controllers/document_detail.coffee
+++ b/packages/controllers/document_detail.coffee
@@ -255,7 +255,7 @@ if Meteor.isClient
           form.submit()
 
     'click #cancel-mturk-job': (event, instance) ->
-      Meteor.call('cancelMechTurkJob', instance.data.documentId)
+      Meteor.call('cancelMechTurkJobs', instance.data.documentId)
 
   Template.documentDetailAnnotation.helpers
     header: ->
@@ -400,11 +400,11 @@ Meteor.methods
     else
       throw new Meteor.Error 'Unauthorized'
 
-  cancelMechTurkJob: (documentId) ->
+  cancelMechTurkJobs: (documentId) ->
     @unblock()
     check documentId, String
     if Meteor.user()?.admin
-      MTurkJobs.findOne(documentId: documentId)?.cancel()
+      Documents.findOne(documentId)?.removeAllRelatedMTurkJobs()
 
 if Meteor.isServer
 


### PR DESCRIPTION
also fixed the modal's form "submit" event
And treating HIT cancel responses as success in case it's already been cancelled before (since we keep all mTurk jobs in the local database)
