### PR TITLE
Fix bug when triple-clicking last paragraph of text

### DIFF
--- a/packages/controllers/document_detail.coffee
+++ b/packages/controllers/document_detail.coffee
@@ -202,14 +202,16 @@ if Meteor.isClient
     'click .document-container': (event, instance) ->
       temporaryAnnotation = instance.temporaryAnnotation.get()
 
+      elementClassName = 'document-text'
       selection = window.getSelection()
       range = selection.getRangeAt(0)
-      selectionInDocument = selection.anchorNode.parentElement.getAttribute('class') == 'document-text'
-      textHighlighted = range and (range.endOffset > range.startOffset)
+      selectionInDocument = selection.anchorNode.parentElement.getAttribute('class') == elementClassName
+      textHighlighted = range and (range.endOffset > range.startOffset or range.endOffset == 0)
+      lastCharOffset = $(".#{elementClassName}").first().text().length
 
       if selectionInDocument and textHighlighted
         startOffset = range.startOffset
-        endOffset = range.endOffset
+        endOffset = range.endOffset or lastCharOffset
 
         temporaryAnnotation.set(startOffset: startOffset, endOffset: endOffset)
         instance.temporaryAnnotation.set(temporaryAnnotation)


### PR DESCRIPTION
When the last paragraph was triple-clicked, the endoffset became 0 which caused problems with the selection.

PT Bug: https://www.pivotaltracker.com/story/show/113004987
