### PR TITLE
Create default group on BSVE instances

### DIFF
--- a/packages/data/bsve_init.coffee
+++ b/packages/data/bsve_init.coffee
@@ -1,0 +1,20 @@
+Meteor.startup ->
+  if process.env.ALLOW_TOKEN_ACCESS is 'true'
+    if not Groups.findOne(name: "BSVE")
+      group = new Group(
+        name: "BSVE"
+      )
+      group.save()
+    if CodingKeywords.find().count() == 0
+      headerId = Headers.insert
+        label: "Disease"
+        color: 1
+      subHeaderId = SubHeaders.insert
+        headerId: headerId
+        label: "Fever"
+      CodingKeywords.insert
+        subHeaderId: subHeaderId
+        label: "Ebola Hemorrhagic Fever"
+      CodingKeywords.insert
+        subHeaderId: subHeaderId
+        label: "Dengue Fever"

--- a/packages/data/package.js
+++ b/packages/data/package.js
@@ -9,4 +9,5 @@ Package.onUse(function(api) {
   api.versionsFrom('1.1.0.2');
   api.use(['coffeescript']);
   api.addFiles('default_codes.coffee', ['server', 'client']);
+  api.addFiles('bsve_init.coffee', ['server']);
 });


### PR DESCRIPTION
This creates a default group called BSVE and also adds some default coding keywords when the ALLOW_TOKEN_ACCESS environment variable is true.
